### PR TITLE
Finish implementation of the My.Feature feature switch

### DIFF
--- a/FeatureCustomTrimming/FeatureCustomTrimming.csproj
+++ b/FeatureCustomTrimming/FeatureCustomTrimming.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -10,14 +10,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <!--<RuntimeHostConfigurationOption Include="My.Feature" Value="false" Trim="true" />-->
+    <RuntimeHostConfigurationOption Include="My.Feature" Value="false" Trim="true" />
   </ItemGroup>
   
 
   <Target Name="PrepareForMyILLink"
           BeforeTargets="PrepareForILLink">
     <ItemGroup>
-      <ManagedAssemblyToLink Condition="$([System.String]::Copy('%(ManagedAssemblyToLink.Filename)').Equals('MyTestApp'))">
+      <ManagedAssemblyToLink Condition="$([System.String]::Copy('%(ManagedAssemblyToLink.Filename)').Equals('FeaturePoweredLibrary'))">
         <IsTrimmable>true</IsTrimmable>
         <TrimMode>link</TrimMode>
       </ManagedAssemblyToLink>

--- a/FeaturePoweredLibrary/FeaturePoweredLibrary.csproj
+++ b/FeaturePoweredLibrary/FeaturePoweredLibrary.csproj
@@ -1,7 +1,17 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Remove="ILLink.Substitutions.xml" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="ILLink.Substitutions.xml">
+      <LogicalName>ILLink.Substitutions.xml</LogicalName>
+    </EmbeddedResource>
+  </ItemGroup>
 
 </Project>

--- a/FeaturePoweredLibrary/ILLink.Substitutions.xml
+++ b/FeaturePoweredLibrary/ILLink.Substitutions.xml
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+
+<linker>
+  <assembly fullname="FeaturePoweredLibrary">
+    <type fullname="FeaturePoweredLibrary.MySwitches">
+      <method signature="System.Boolean get_IsMyFeatureEnabled()" body="stub" value="false"
+              feature="My.Feature" featurevalue="false" />
+    </type>
+  </assembly>
+</linker>


### PR DESCRIPTION
This adds the necessary `ILLink.Substitutions.xml` to tell trimming what effect the `My.Feature` has on the code.
And then it wires it up in the main project and sets the value.

When I publish this with trimming turned on, the body of `MyLibrary.PrintHello` looks like this:
```C#
public void PrintHello()
{
	if (MySwitches.IsMyFeatureEnabled)
	{
	}
	Console.WriteLine("My.Feature is disabled");
}
```